### PR TITLE
Integrate Sentry error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ KYO_QA_ServiceNow_Knowledge_Tool_v25.1.1/\
 3. Run `START.bat` (Windows) or `python run.py`:
    - Sets up `/venv/` and installs dependencies from `requirements.txt`.
    - Outputs logs to `/logs/` and Excel to `/output/`.
+   - Set `SENTRY_DSN` in your environment to enable cloud error reporting.
 4. Manual setup (if needed):
 
    ```bash
@@ -171,6 +172,7 @@ Requires `pandas`, `PyMuPDF`, `openpyxl`, `pytesseract`, `python-dateutil`, `col
 - Session logs in `/logs/[YYYY-MM-DD_HH-MM-SS]_session.log`.
 - Success/failure logs as `[YYYYMMDD]_SUCCESSlog.md` or `FAILlog.md` in `/logs/`.
 - Text files for documents needing review (e.g., failed model extraction) in `/PDF_TXT/needs_review/*.txt`.
+- Optional Sentry reporting: set the environment variable `SENTRY_DSN` with your project DSN to forward errors to Sentry.
 
 ## Portable Deployment
 

--- a/error_tracker.py
+++ b/error_tracker.py
@@ -1,0 +1,28 @@
+import os
+import logging
+
+from sentry_sdk import init
+from sentry_sdk.integrations.logging import LoggingIntegration, EventHandler
+
+_initialized = False
+_handler: logging.Handler | None = None
+
+
+def init_error_tracker() -> bool:
+    """Initialize Sentry error tracking if a DSN is provided."""
+    global _initialized, _handler
+    if _initialized:
+        return True
+    dsn = os.getenv("SENTRY_DSN")
+    if not dsn:
+        return False
+    sentry_logging = LoggingIntegration(level=logging.ERROR, event_level=logging.ERROR)
+    init(dsn=dsn, integrations=[sentry_logging])
+    _handler = EventHandler(level=logging.ERROR)
+    _initialized = True
+    return True
+
+
+def get_handler() -> logging.Handler | None:
+    """Return the Sentry logging handler if initialized."""
+    return _handler

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
+import error_tracker
 
 LOG_DIR = Path.cwd() / "logs"
 LOG_DIR.mkdir(exist_ok=True)
@@ -57,6 +58,12 @@ def setup_logger(name: str, level=logging.INFO, log_widget=None) -> logging.Logg
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         root_logger.addHandler(console_handler)
+
+        if error_tracker.init_error_tracker():
+            sentry_handler = error_tracker.get_handler()
+            if sentry_handler:
+                sentry_handler.setFormatter(formatter)
+                root_logger.addHandler(sentry_handler)
 
         root_logger.info(f"Logging initialized for session. Log file: {SESSION_LOG_FILE}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dateutil>=2.9.0
 ollama>=0.1.2
 extract
 opencv-python>=4.9.0
+sentry-sdk>=1.39.0

--- a/tests/test_error_tracker.py
+++ b/tests/test_error_tracker.py
@@ -1,0 +1,38 @@
+import logging
+import importlib
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import config
+
+
+def test_sentry_handler_added(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "LOGS_DIR", tmp_path)
+    monkeypatch.setenv("SENTRY_DSN", "http://example.com/123")
+
+    import logging_utils
+    importlib.reload(logging_utils)
+    monkeypatch.setattr(logging_utils, "SESSION_LOG_FILE", tmp_path / "session.log")
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    logging_utils.setup_logger("test")
+
+    assert any(h.__class__.__name__ == "EventHandler" for h in root_logger.handlers)
+
+
+def test_sentry_handler_not_added(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "LOGS_DIR", tmp_path)
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    import logging_utils
+    importlib.reload(logging_utils)
+    monkeypatch.setattr(logging_utils, "SESSION_LOG_FILE", tmp_path / "session.log")
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    logging_utils.setup_logger("test")
+
+    assert not any(h.__class__.__name__ == "EventHandler" for h in root_logger.handlers)


### PR DESCRIPTION
## Summary
- add new `error_tracker` helper for initializing Sentry
- forward log exceptions to Sentry from `logging_utils`
- document optional Sentry setup
- include `sentry-sdk` dependency
- test that Sentry handler wiring works

## Testing
- `ruff check error_tracker.py logging_utils.py tests/test_error_tracker.py`
- `pytest -q tests/test_error_tracker.py tests/test_logging_utils.py` *(fails: ModuleNotFoundError: No module named 'sentry_sdk')*
- `pip install sentry-sdk` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6865e0635604832eafe298dfe2852f25