### PR TITLE
Add optional Sentry reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ KYO_QA_ServiceNow_Knowledge_Tool_v25.1.1/\
 3. Run `START.bat` (Windows) or `python run.py`:
    - Sets up `/venv/` and installs dependencies from `requirements.txt`.
    - Outputs logs to `/logs/` and Excel to `/output/`.
+   - *(Optional)* Set the `SENTRY_DSN` environment variable if you want errors
+     reported to your Sentry dashboard.
 4. Manual setup (if needed):
 
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dateutil>=2.9.0
 ollama>=0.1.2
 extract
 opencv-python>=4.9.0
+sentry-sdk>=1.39.0

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,6 +1,8 @@
 import logging
 import importlib
+import sys
 import config
+import types
 
 
 def test_setup_logger_to_console_flag(tmp_path, monkeypatch):
@@ -38,4 +40,28 @@ def test_setup_logger_to_console_flag(tmp_path, monkeypatch):
 
     assert after_no_console == initial_streams
     assert after_console >= after_no_console + 1
+
+
+def test_setup_logger_initializes_sentry(monkeypatch, tmp_path):
+    called = []
+    fake_sdk = type(
+        "Fake",
+        (),
+        {
+            "Hub": type("Hub", (), {"current": type("cur", (), {"client": None})()}),
+            "init": lambda dsn=None: called.append(dsn),
+            "capture_exception": lambda exc: called.append("cap")
+        },
+    )
+    monkeypatch.setenv("SENTRY_DSN", "xyz")
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake_sdk)
+    monkeypatch.setitem(sys.modules, "openpyxl", types.ModuleType("openpyxl"))
+    monkeypatch.setattr(config, "LOGS_DIR", tmp_path)
+    logging.getLogger().handlers.clear()
+    import logging_utils
+    import importlib
+    importlib.reload(logging_utils)
+    monkeypatch.setattr(logging_utils, "SESSION_LOG_FILE", tmp_path / "file.log")
+    logger = logging_utils.setup_logger("t")
+    assert "xyz" in called
 


### PR DESCRIPTION
## Summary
- integrate sentry_sdk in the logger
- use environment variable `SENTRY_DSN`
- catch exceptions in `run.py` and report to Sentry
- document optional DSN in README
- update unit tests for Sentry setup
- add `sentry_sdk` to requirements

## Testing
- `ruff check .`
- `PYTHONPATH=/tmp/mockpkg:. pytest tests/test_logging_utils.py::test_setup_logger_initializes_sentry -q`
- `PYTHONPATH=/tmp/mockpkg:. pytest -q` *(fails: ImportError: cannot import name 'Alignment' from 'openpyxl.styles')*

------
https://chatgpt.com/codex/tasks/task_e_6865e02a2894832e8b8d80f5f441164e