### PR TITLE
Clean requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This tool extracts model numbers (e.g., `PF-740`, `TASKalfa AB-1234abcd`, `ECOSY
 
 - **Python 3.11.x (64-bit):** Download Python 3.11.9 Windows Installer or use a portable version in `python-3.11.9` folder.
 - **Tesseract OCR:** Tesseract Windows Installer (UB Mannheim) or place portable binary in `tesseract` folder.
-- **Dependencies:** Listed in `requirements.txt` (auto-installed via `run.py`).
+- **Dependencies:** Listed in `requirements.txt` (auto-installed via `run.py`). No extra packages like `ollama` or `extract` are needed.
 
 ### 2. Folder Structure
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,4 @@ Pillow>=10.3.0
 pytesseract>=0.3.11
 colorama>=0.4.6
 python-dateutil>=2.9.0
-ollama>=0.1.2
-extract
 opencv-python>=4.9.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,7 @@
+import pathlib
+
+
+def test_no_ollama_extract_in_requirements():
+    reqs = pathlib.Path('requirements.txt').read_text().splitlines()
+    assert all('ollama' not in line for line in reqs)
+    assert all('extract' not in line for line in reqs)


### PR DESCRIPTION
## Summary
- drop unused `ollama` and `extract` packages
- note removed packages in install docs
- test to ensure requirements file stays clean

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ImportError - openpyxl & PIL missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865e0245cc4832ebccb4e6a58fa9df6